### PR TITLE
feat(unix): add support for unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ These are the default options, you don't need to copy them into `setup()`
 ```lua
 require('rayso').setup {
   base_url = 'https://ray.so/', -- Default URL
-  open_cmd = 'firefox', -- On MacOS, will open with open -a firefox.app. Other OS's are untested.
+  open_cmd = 'firefox', -- On MacOS, will open with open -a firefox.app. In unix, will open with xdg-open firefox. Other OS's are untested.
   options = {
     background = true, -- If the screenshot should have a background.
     dark_mode = true, -- If the screenshot should be in dark mode.

--- a/lua/lib/create.lua
+++ b/lua/lib/create.lua
@@ -9,15 +9,24 @@ M.get_open_command = function()
     -- return 'open -a ' .. rayso.config.open_cmd .. '.app'
     return 'open'
   end
-
   if vim.fn.has 'win32' == 1 then
     return 'start ' .. rayso.config.open_cmd
   end
-  -- Not an mac and command is not an executable
+  -- On Linux
+  if vim.fn.has 'unix' == 1 then
+    -- Try common Linux open commands in order of preference
+    if vim.fn.executable 'xdg-open' == 1 then
+      return 'xdg-open'
+    elseif vim.fn.executable(rayso.config.open_cmd) == 1 then
+      return rayso.config.open_cmd
+    else
+      return error('Could not find xdg-open or ' .. rayso.config.open_cmd)
+    end
+  end
+  -- Not a mac/windows/linux and command is not an executable
   if vim.fn.executable(rayso.config.open_cmd) == 0 then
     return error('Could not find executable for ' .. rayso.config.open_cmd)
   end
-
   return rayso.config.open_cmd
 end
 


### PR DESCRIPTION
## Add Linux support to open command

### Summary
Adds support for opening files/URLs on Linux systems by using `xdg-open`.

### Changes
- Added detection for Linux/Unix systems using `vim.fn.has 'unix'`
- Uses `xdg-open` as the default command for Linux (standard across most distributions)
- Falls back to `rayso.config.open_cmd` if available and executable
- Improved error messaging for unsupported configurations

### Testing
Tested on Arch Linux with `xdg-open` available.

### Notes
`xdg-open` is the standard utility for opening files/URLs with the default application on Linux desktop environments and should work across most distributions.